### PR TITLE
Fix old model rendering for left hand

### DIFF
--- a/common/src/main/java/mod/adrenix/nostalgic/mixin/client/ItemInHandRendererMixin.java
+++ b/common/src/main/java/mod/adrenix/nostalgic/mixin/client/ItemInHandRendererMixin.java
@@ -198,7 +198,12 @@ public abstract class ItemInHandRendererMixin
     @Inject(method = "renderItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/ItemRenderer;renderStatic(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/client/renderer/block/model/ItemTransforms$TransformType;ZLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/level/Level;III)V"))
     protected void onRenderItem(LivingEntity livingEntity, ItemStack itemStack, ItemTransforms.TransformType transformType, boolean leftHand, PoseStack poseStack, MultiBufferSource buffer, int combinedLight, CallbackInfo callback)
     {
-        if (MixinConfig.Candy.oldItemHolding())
+        if (MixinConfig.Candy.oldItemHolding() && leftHand == true)
+        {
+            poseStack.mulPose(Vector3f.YP.rotationDegrees(-5F));
+            poseStack.translate(0.01F, -0.01F, -0.015F);
+        }
+        else if (MixinConfig.Candy.oldItemHolding()) 
         {
             poseStack.mulPose(Vector3f.YP.rotationDegrees(5F));
             poseStack.translate(-0.01F, -0.01F, -0.015F);


### PR DESCRIPTION
Unless I screwed up this should fix the problem so that both hand models are perfectly mirrored. 