### PR TITLE
Allow people to override smooth lighting as a tweak

### DIFF
--- a/common/src/main/java/mod/adrenix/nostalgic/config/ClientConfig.java
+++ b/common/src/main/java/mod/adrenix/nostalgic/config/ClientConfig.java
@@ -498,6 +498,7 @@ public class ClientConfig implements ConfigMeta
         public boolean oldSmoothLighting = CandyTweak.OLD_SMOOTH_LIGHTING.register("oldSmoothLighting");
         public boolean oldNetherLighting = CandyTweak.OLD_NETHER_LIGHTING.register("oldNetherLighting");
         public boolean oldClassicEngine = CandyTweak.OLD_CLASSIC_ENGINE.register("oldClassicEngine");
+        public boolean disableSmoothLighting = CandyTweak.DISABLE_SMOOTH_LIGHTING.register("disableSmoothLighting");
 
         // Lightmap Texture
 

--- a/common/src/main/java/mod/adrenix/nostalgic/mixin/tweak/candy/world_lighting/MinecraftMixin.java
+++ b/common/src/main/java/mod/adrenix/nostalgic/mixin/tweak/candy/world_lighting/MinecraftMixin.java
@@ -1,0 +1,25 @@
+package mod.adrenix.nostalgic.mixin.tweak.candy.world_lighting;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.mojang.authlib.minecraft.client.MinecraftClient;
+import mod.adrenix.nostalgic.tweak.config.CandyTweak;
+import mod.adrenix.nostalgic.util.client.GameUtil;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Minecraft.class)
+public abstract class MinecraftMixin
+{
+
+    @ModifyReturnValue(
+            method = "useAmbientOcclusion",
+            at = @At("RETURN")
+    )
+    private static boolean nt_world_lighting$overrideSmoothLighting(boolean original)
+    {
+        if (CandyTweak.DISABLE_SMOOTH_LIGHTING.get())
+            return false;
+        return original;
+    }
+}

--- a/common/src/main/java/mod/adrenix/nostalgic/tweak/config/CandyTweak.java
+++ b/common/src/main/java/mod/adrenix/nostalgic/tweak/config/CandyTweak.java
@@ -339,6 +339,7 @@ public interface CandyTweak
     TweakFlag OLD_SMOOTH_LIGHTING = TweakFlag.client(true, CandyGroup.LIGHTING_WORLD_ENGINE).reloadChunks().build();
     TweakFlag OLD_NETHER_LIGHTING = TweakFlag.client(true, CandyGroup.LIGHTING_WORLD_ENGINE).reloadChunks().build();
     TweakFlag OLD_CLASSIC_ENGINE = TweakFlag.server(false, CandyGroup.LIGHTING_WORLD_ENGINE).reloadChunks().warningTag().build();
+    TweakFlag DISABLE_SMOOTH_LIGHTING = TweakFlag.client(false, CandyGroup.LIGHTING_WORLD_ENGINE).newForUpdate().reloadChunks().build();
 
     // Lightmap Texture
 

--- a/common/src/main/resources/assets/nostalgic_tweaks/lang/en_us.json
+++ b/common/src/main/resources/assets/nostalgic_tweaks/lang/en_us.json
@@ -1346,6 +1346,8 @@
   "gui.nostalgic_tweaks.config.eyeCandy.chestLightBlock": "Chest Light Blocking",
   "gui.nostalgic_tweaks.config.eyeCandy.chestLightBlock.info": "Recalculate chunk lighting so that chests block skylight and block light.",
   "gui.nostalgic_tweaks.config.eyeCandy.chestLightBlock.conflict": "This tweak will not work when§e Starlight§r is installed.",
+  "gui.nostalgic_tweaks.config.eyeCandy.disableSmoothLighting": "Disable Smooth Lighting",
+  "gui.nostalgic_tweaks.config.eyeCandy.disableSmoothLighting.info": "Override the game's smooth lighting setting",
   "gui.nostalgic_tweaks.config.eyeCandy.roundRobinRelight": "Round Robin Chunk Relighting",
   "gui.nostalgic_tweaks.config.eyeCandy.roundRobinRelight.info": "When skylight changes due to the time of day, this will cause§6 round robin chunk updates§r. This will have a slight§c impact§r on performance when relighting occurs.",
   "gui.nostalgic_tweaks.config.eyeCandy.roundRobinRelight.conflict": "This tweak will not work if§e Starlight§r or§b Distant Horizons§r is installed.",

--- a/common/src/main/resources/mixin.nostalgic_tweaks.json
+++ b/common/src/main/resources/mixin.nostalgic_tweaks.json
@@ -103,6 +103,7 @@
     "candy.world_lighting.LightingMixin",
     "candy.world_lighting.LightTextureMixin",
     "candy.world_lighting.LiquidBlockRendererMixin",
+    "candy.world_lighting.MinecraftMixin",
     "candy.world_sky.BiomeMixin",
     "candy.world_sky.ClientLevelMixin",
     "candy.world_sky.DimensionSpecialEffectsMixin",


### PR DESCRIPTION
Useful for when you enable/disable the mod or for versoin presets.