### PR TITLE
Make debug charts accurate to old versions

### DIFF
--- a/common/src/main/java/mod/adrenix/nostalgic/helper/candy/debug/DebugChartRenderer.java
+++ b/common/src/main/java/mod/adrenix/nostalgic/helper/candy/debug/DebugChartRenderer.java
@@ -42,8 +42,8 @@ class DebugChartRenderer
         int numOfValues = this.logger.size() - maxSize;
 
         this.graphics.pose().pushPose();
-        this.graphics.pose().translate(0.0F, this.graphics.guiHeight() - (this.height / 2.0F), 0.0F);
-        this.graphics.pose().scale(0.5F, 0.5F, 0.5F);
+        this.graphics.pose().translate(0.0F, this.graphics.guiHeight() - this.height, 0.0F);
+        //this.graphics.pose().scale(0.5F, 0.5F, 0.5F);
         this.graphics.fill(RenderType.guiOverlay(), 0, 0, this.width, this.height, 0x90200000);
         this.graphics.fill(RenderType.guiOverlay(), 0, 36, this.width, this.height, 0x90000000);
 

--- a/common/src/main/java/mod/adrenix/nostalgic/helper/candy/debug/DebugInfoRenderer.java
+++ b/common/src/main/java/mod/adrenix/nostalgic/helper/candy/debug/DebugInfoRenderer.java
@@ -195,7 +195,7 @@ class DebugInfoRenderer
         String title = overlay.isEmpty() ? "Minecraft " + GameUtil.getVersion() : overlay;
         String fps = String.format(" (%s fps, %s chunk updates)", this.minecraft.getFps(), chunkUpdates);
         String sections = String.format("C: %d/%d. F: 0, O: 0, E: 0", this.levelRenderer.countRenderedSections(), (long) this.levelRenderer.getTotalSections());
-        String entities = String.format("E: %s/%s. B: %s, I: 0", renderedEntities, this.level.getEntityCount(), culledEntities);
+        String entities = String.format("E: %s/%s. B: %s, I: %s", renderedEntities, this.level.getEntityCount(), culledEntities, this.level.getEntityCount() - renderedEntities - culledEntities);
         String particles = String.format("P: %s. T: All: %s", this.minecraft.particleEngine.countParticles(), this.level.getEntityCount());
         String overflow = String.format(" (%s fps)", this.minecraft.getFps());
 
@@ -229,14 +229,15 @@ class DebugInfoRenderer
 
         if (CandyTweak.OLD_DEBUG.get() == Generic.BETA)
         {
-            this.left.add(String.format("ChunkCache: %d", this.level.getChunkSource().getLoadedChunksCount()));
+            this.left.add(String.format("ServerChunkCache: %d Drop: 0", this.level.getChunkSource().getLoadedChunksCount()));
 
             if (!this.isReducedInfo)
             {
                 this.left.add("");
-                this.left.add(String.format("X: %f", this.player.getX()));
-                this.left.add(String.format("Y: %f", this.player.getY()));
-                this.left.add(String.format("Z: %f", this.player.getZ()));
+                this.left.add("x: " + this.player.getX());
+                this.left.add("y: " + this.player.getEyeY());
+                this.left.add("z: " + this.player.getZ());
+                this.left.add("f: " + this.player.getDirection().get2DDataValue());
             }
         }
     }


### PR DESCRIPTION
Rebased variant of #180, because apparently GitHub doesn't allow switching source branches and I wrote this code a year ago so it wasn't properly branched.